### PR TITLE
Use a transparent 1x1 image for headerURL

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -1,5 +1,8 @@
 import { makeLog, colorToCSS } from '../lib/utils';
 
+// Blank 1x1 PNG from http://png-pixel.com/
+const BLANK_IMAGE = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
 const log = makeLog('background');
 
 const bgImages = require.context('../images/', false, /bg-.*\.png/);
@@ -53,7 +56,9 @@ const applyTheme = ({ theme }) => {
 
   const newTheme = {
     images: {
-      headerURL: backgroundImage,
+      // HACK: use a transparent pixel image for headerURL - because headerURL
+      // won't tile but additional_backgrounds won't appear without it.
+      headerURL: BLANK_IMAGE,
       additional_backgrounds: [backgroundImage]
     },
     properties: {


### PR DESCRIPTION
This is a hack for an upstream limitation in the theme API

We can set `images.headerURL` which gives us a *non-tiling* image
anchored to the upper right. That's where the first  of the doubles
appears.

We can set `images.additional_backgrounds` which gives us images
that have customizable alignment and tiling.

If we don't set `headerURL`, we don't get the additional backgrounds at
all. So, here's a hack to set a transparent pixel for `headerURL`

Fixes #22