### PR TITLE
Add a loading overlay while the app initializes

### DIFF
--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -12,7 +12,8 @@ export const actions = {
     'SET_SELECTED_COLOR',
     'SET_HAS_EXTENSION',
     'SET_PENDING_THEME',
-    'CLEAR_PENDING_THEME'
+    'CLEAR_PENDING_THEME',
+    'SET_LOADER_DELAY_EXPIRED'
   ),
   theme: {
     ...createActions({}, ...themeChangeActions),
@@ -30,6 +31,7 @@ const themesEqual = (themeA, themeB) =>
 
 export const selectors = {
   hasExtension: state => state.ui.hasExtension,
+  loaderDelayExpired: state => state.ui.loaderDelayExpired,
   selectedColor: state => state.ui.selectedColor,
   shouldOfferPendingTheme: state =>
     !state.ui.userHasEdited &&
@@ -57,6 +59,10 @@ export const reducers = {
         ...state,
         hasExtension
       }),
+      SET_LOADER_DELAY_EXPIRED: (state, { payload: loaderDelayExpired }) => ({
+        ...state,
+        loaderDelayExpired
+      }),
       SET_THEME: (state, { meta }) => ({
         ...state,
         userHasEdited: meta && meta.userEdit ? true : state.userHasEdited
@@ -68,7 +74,8 @@ export const reducers = {
       userHasEdited: false,
       pendingTheme: null,
       selectedColor: 'toolbar',
-      hasExtension: false
+      hasExtension: false,
+      loaderDelayExpired: false
     }
   ),
   theme: undoable(

--- a/src/web/lib/components/App/index.js
+++ b/src/web/lib/components/App/index.js
@@ -10,6 +10,7 @@ import PresetThemeSelector from '../PresetThemeSelector';
 import ThemeBackgroundPicker from '../ThemeBackgroundPicker';
 import ExtensionInstallButton from '../ExtensionInstallButton';
 import SharedThemeDialog from '../SharedThemeDialog';
+import AppLoadingIndicator from '../AppLoadingIndicator';
 import ThemeUrl from '../ThemeUrl';
 
 import './index.scss';
@@ -19,6 +20,7 @@ const mapStateToProps = state => ({
   themeCanUndo: selectors.themeCanUndo(state),
   themeCanRedo: selectors.themeCanRedo(state),
   hasExtension: selectors.hasExtension(state),
+  loaderDelayExpired: selectors.loaderDelayExpired(state),
   selectedColor: selectors.selectedColor(state),
   shouldOfferPendingTheme: selectors.shouldOfferPendingTheme(state),
   pendingTheme: selectors.pendingTheme(state)
@@ -45,6 +47,7 @@ export const AppComponent = ({
   themeCanUndo,
   themeCanRedo,
   hasExtension,
+  loaderDelayExpired,
   selectedColor,
   setColor,
   pendingTheme,
@@ -57,6 +60,7 @@ export const AppComponent = ({
   redo
 }) =>
   <div className="app">
+    {!loaderDelayExpired && <AppLoadingIndicator />}
     {hasExtension && shouldOfferPendingTheme &&
       <SharedThemeDialog {...{ pendingTheme, setTheme, clearPendingTheme }} />}
     <AppBackground {...{ theme }} />

--- a/src/web/lib/components/AppLoadingIndicator/index.js
+++ b/src/web/lib/components/AppLoadingIndicator/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import './index.scss';
+
+export const AppLoadingIndicator = () => (
+  <div className="app-loading-indicator">
+    <p>𝕽</p>
+  </div>
+);
+
+export default AppLoadingIndicator;

--- a/src/web/lib/components/AppLoadingIndicator/index.scss
+++ b/src/web/lib/components/AppLoadingIndicator/index.scss
@@ -1,0 +1,28 @@
+@import '../../common.scss';
+
+.app-loading-indicator {
+  align-items: center;
+  background: rgba(12,12,13,0.95);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 20000;
+
+  p {
+    font-size: 600%;
+    color: white;
+    animation-name: rotate;
+    animation-duration: 2s;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+  }
+}
+
+@keyframes rotate {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(359deg); }
+}


### PR DESCRIPTION
- Add AppLoadingIndicator component that overlays app on startup

- Implements a timer that resets with every Redux store change. If no
  changes happen and the timer expires, we consider the app loaded -
  assuming that no more state changes means it's done loading.

- If there's no shared ?theme parameter, we start a timer immediately
  after asking for current theme from add-on. If the add-on never
  answers, the app considers itself loaded after the delay expires.

- If there's a shared ?theme parameter, we decode the parameter and the
  first state change starts the timer - thus giving things time to at
  least handle the shared theme.

Fixes #62