### PR TITLE
Enforce normal structure for internal theme data

### DIFF
--- a/src/extension/background.js
+++ b/src/extension/background.js
@@ -1,4 +1,4 @@
-import { makeLog, colorToCSS } from '../lib/utils';
+import { makeLog, colorToCSS, normalizeTheme } from '../lib/utils';
 
 // Blank 1x1 PNG from http://png-pixel.com/
 const BLANK_IMAGE = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
@@ -31,8 +31,9 @@ const messageHandlers = {
       port.postMessage({ type: 'fetchedTheme', theme })
     );
   },
-  setTheme: ({ message: { theme } }) => {
-    log('setTheme', theme);
+  setTheme: ({ message: { theme: themeIn } }) => {
+    log('setTheme', themeIn);
+    const theme = normalizeTheme(themeIn);
     storeTheme({ theme });
     applyTheme({ theme });
   },
@@ -47,7 +48,6 @@ const storeTheme = ({ theme }) => browser.storage.local.set({ theme });
 
 const applyTheme = ({ theme }) => {
   log('applyTheme', theme);
-
   if (!theme) { return; }
 
   const backgroundImage = bgImages.keys().includes(theme.images.headerURL)

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,7 +1,11 @@
 import { createStore, combineReducers } from 'redux';
 import { createActions, handleActions } from 'redux-actions';
 import undoable, { ActionCreators } from 'redux-undo';
-import { defaultColors } from './constants';
+import {
+  normalizeTheme,
+  normalizeThemeColor,
+  normalizeThemeColors
+} from './utils';
 
 // Actions that should trigger a theme update in URL history and the add-on
 export const themeChangeActions = ['SET_THEME', 'SET_COLOR', 'SET_BACKGROUND'];
@@ -46,7 +50,7 @@ export const reducers = {
     {
       SET_PENDING_THEME: (state, { payload: { theme } }) => ({
         ...state,
-        pendingTheme: theme
+        pendingTheme: normalizeTheme(theme)
       }),
       CLEAR_PENDING_THEME: state => ({ ...state, pendingTheme: null }),
       SET_SELECTED_COLOR: (state, { payload: { name } }) => ({
@@ -74,21 +78,24 @@ export const reducers = {
   theme: undoable(
     handleActions(
       {
-        SET_THEME: (state, { payload: { theme } }) => ({ ...theme }),
-        SET_COLORS: (state, { payload: { colors } }) => ({ ...state, colors }),
+        SET_THEME: (state, { payload: { theme } }) => normalizeTheme(theme),
+        SET_COLORS: (state, { payload: { colors } }) => ({
+          ...state,
+          colors: normalizeThemeColors(colors)
+        }),
         SET_COLOR: (state, { payload: { name, h, s, l, a } }) => ({
           ...state,
-          colors: { ...state.colors, [name]: { h, s, l, a } }
+          colors: {
+            ...state.colors,
+            [name]: normalizeThemeColor({ h, s, l, a })
+          }
         }),
         SET_BACKGROUND: (state, { payload: { url } }) => ({
           ...state,
           images: { ...state.images, headerURL: url }
         })
       },
-      {
-        images: { headerURL: '' },
-        colors: defaultColors
-      }
+      normalizeTheme()
     )
   )
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,19 +1,46 @@
+import { defaultColors } from './constants';
+
 export const DEBUG = process.env.NODE_ENV === 'development';
 
 export const makeLog = context => (...args) =>
   // eslint-disable-next-line no-console
   DEBUG && console.log(`[ThemesRFun ${context}]`, ...args);
 
-export const floorHSLA = color => ({
-  h: Math.floor(color.h),
-  s: Math.floor(color.s),
-  l: Math.floor(color.l),
-  a: color.a
-});
-
 export const colorToCSS = color => {
-  const { h, s, l, a } = floorHSLA(color);
+  const { h, s, l, a } = color;
   return typeof a === 'undefined'
     ? `hsl(${h}, ${s}%, ${l}%)`
     : `hsla(${h}, ${s}%, ${l}%, ${a * 0.01})`;
+};
+
+// Utility to ensure normal & consistent colors
+export const normalizeThemeColor = (data, defaultColor) => {
+  const { h, s, l, a } = data || defaultColor;
+  return {
+    h: Math.floor(h),
+    s: Math.floor(s),
+    l: Math.floor(l),
+    a
+  };
+};
+
+export const normalizeThemeColors = (colors = {}) => {
+  const out = {};
+  Object.keys(defaultColors).forEach(name => {
+    out[name] = normalizeThemeColor(colors[name], defaultColors[name]);
+  });
+  return out;
+};
+
+// Utility to ensure normal properties and values in app theme state
+export const normalizeTheme = (data = {}) => {
+  const theme = {
+    colors: normalizeThemeColors(data.colors, defaultColors),
+    images: { headerURL: '' }
+  };
+  const images = data.images ? data.images : {};
+  if (images.headerURL) {
+    theme.images.headerURL = images.headerURL;
+  }
+  return theme;
 };

--- a/src/web/lib/components/ThemeColorsEditor/index.js
+++ b/src/web/lib/components/ThemeColorsEditor/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import classnames from 'classnames';
 import { SketchPicker } from 'react-color';
 import { colorLabels, colorsWithAlpha } from '../../../../lib/constants';
-import { floorHSLA, colorToCSS } from '../../../../lib/utils';
+import { colorToCSS } from '../../../../lib/utils';
 
 import './index.scss';
 
@@ -64,15 +64,7 @@ export default class ThemeColorsEditor extends React.Component {
                   color={{ h: color.h, s: color.s, l: color.l, a: color.a * 0.01 }}
                   disableAlpha={!colorsWithAlpha.includes(name)}
                   onChangeComplete={({ hsl: { h, s, l, a } }) =>
-                    setColor({
-                      name,
-                      ...floorHSLA({
-                        h,
-                        s: s * 100,
-                        l: l * 100,
-                        a: a * 100
-                      })
-                    })}
+                    setColor({ name, h, s: s * 100, l: l * 100, a: a * 100 })}
                 />
               </dd>
             ];


### PR DESCRIPTION
Add filter functions to ensure we have conistent theme data. This
should ensure that whatever gets passed in as a shared ?theme param is
handled gracefully, and that arbitrary data isn't accepted by the
add-on.

Fixes #50