### PR TITLE
Tweak a bunch of a11y settings from aXe

### DIFF
--- a/src/web/index.html.ejs
+++ b/src/web/index.html.ejs
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Firefox Theme Generator</title>
-    <link rel="icon" type="image/svg+xml" href="images/icon.svg">
+    <link rel="icon" type="image/svg+xml" href="images/icon.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/web/index.html.ejs
+++ b/src/web/index.html.ejs
@@ -2,6 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="description" content="Theming demo for Firefox Quantum and beyond." />
     <title>Firefox Theme Generator</title>
     <link rel="icon" type="image/svg+xml" href="images/icon.svg" />
   </head>

--- a/src/web/lib/components/App/index.js
+++ b/src/web/lib/components/App/index.js
@@ -76,7 +76,7 @@ export const AppComponent = ({
     <AppBackground {...{ theme }} />
     {!hasExtension && <Banner {...{ addonUrl, bottom: false }} />}
     {loaderDelayExpired && (
-      <div className="app__content">
+      <main className="app__content">
         <AppHeader {...{ hasExtension }} />
         <BrowserPreview {...{ theme, setSelectedColor, size: 'large' }}>
           <div className="app__theme-element-pickers">
@@ -117,7 +117,7 @@ export const AppComponent = ({
             }}
           />
         )}
-      </div>
+      </main>
     )}
     <AppFooter />
   </div>

--- a/src/web/lib/components/AppFooter/index.js
+++ b/src/web/lib/components/AppFooter/index.js
@@ -8,8 +8,8 @@ import './index.scss';
 
 export const AppFooter = () =>
   <footer className="app-footer">
-    <div className="app-footer__legal">
-      <a className="app-footer__legal-link" href="https://www.mozilla.org">
+    <nav className="app-footer__legal">
+      <a className="app-footer__legal-link" href="https://www.mozilla.org" aria-label="Mozilla logo">
         <ReactSVG path={ iconMoz } className="app-footer__legal-logo"/>
       </a>
       <a className="app-footer__legal-link" href="https://www.mozilla.org/about/legal">
@@ -27,15 +27,15 @@ export const AppFooter = () =>
       <a className="app-footer__legal-link" href="https://www.mozilla.org/privacy/websites/#cookies">
         Cookies
       </a>
-    </div>
-    <div className="app-footer__social">
-      <a className="app-footer__social-link" href="https://twitter.com/FxTestPilot">
+    </nav>
+    <nav className="app-footer__social">
+      <a className="app-footer__social-link" href="https://twitter.com/FxTestPilot" aria-label="@FxTestPilot Twitter">
         <ReactSVG path={ iconTwitter } className="app-footer__social-logo"/>
       </a>
-      <a className="app-footer__social-link" href="https://github.com/mozilla/ThemesRFun/">
+      <a className="app-footer__social-link" href="https://github.com/mozilla/ThemesRFun/" aria-label="Themer GitHub">
         <ReactSVG path={ iconGH } className="app-footer__social-logo"/>
       </a>
-    </div>
+    </nav>
   </footer>;
 
 export default AppFooter;

--- a/src/web/lib/components/ThemeUrl/index.js
+++ b/src/web/lib/components/ThemeUrl/index.js
@@ -46,7 +46,7 @@ export default class ThemeUrl extends React.Component {
 
     return (
       <form className="theme-url" onSubmit={e => e.preventDefault()}>
-        <label><h2>Share your theme</h2></label>
+        <label htmlFor="themeUrl"><h2>Share your theme</h2></label>
         <fieldset>
           <input type="text" id="themeUrl" value={themeUrl} />
           <input type="submit" className="clipboardButton"


### PR DESCRIPTION
Addresses a bunch of results from aXe, except for ~20 color contrast issues.
Will probably want to run this through a few other a11y linters to make sure I didn't miss some stuff.

### Current status:

![lighthousereport](https://user-images.githubusercontent.com/557895/36622973-58a5d5a6-18b5-11e8-871e-0adae430d32e.png)

...

![lighthousereport2](https://user-images.githubusercontent.com/557895/36622988-7e680462-18b5-11e8-90df-3f1831219eb2.png)

That "Performance" number is probably v.misleading since I'm running locally on probably an `process.env.NODE_ENV=development` build.
