### PR TITLE
Implement current set of metrics pings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   ],
   "private": true,
   "main": "src/web/index.js",
+  "config": {
+    "GA_TRACKING_ID": "UA-114768519-1"
+  },
   "scripts": {
     "start": "npm-run-all --parallel server watch:extension watch:lint",
     "server": "cross-env NODE_ENV=development webpack-dev-server --config webpack.web.js",
@@ -83,7 +86,8 @@
     "redux": "^3.7.2",
     "redux-actions": "^2.2.1",
     "redux-devtools-extension": "^2.13.2",
-    "redux-undo": "^1.0.0-beta9-9-7"
+    "redux-undo": "^1.0.0-beta9-9-7",
+    "testpilot-ga": "^0.3.0"
   },
   "extensionManifest": {
     "name": "ThemesRFun",

--- a/src/lib/metrics.js
+++ b/src/lib/metrics.js
@@ -1,0 +1,278 @@
+import TestPilotGA from 'testpilot-ga';
+
+// Use of package.json for configuration
+import packageMeta from '../../package.json';
+
+import { DEBUG, makeLog } from './utils';
+import { selectors } from './store';
+import { colorsWithAlpha } from './constants';
+
+const log = makeLog('metrics');
+
+let analytics = null;
+
+// Time after which to consider add-on install to have failed, because we have
+// no good way to tell if the install has been cancelled - only if the add-on
+// becomes available
+const INSTALL_FAILURE_DELAY = 10 * 1000;
+let installTimer = null;
+
+// See also: https://github.com/mozilla/ThemesRFun/blob/master/docs/metrics.md
+
+// Custom metrics
+let cm1; // integer count of select-full events from start of visit
+let cm2; // integer count of select-bg events from start of visit
+let cm3; // integer count of select-color events from start of visit
+
+// Custom dimensions
+let cd1; // does the user have the add-on installed. One of true or false
+let cd2; // did this visit originate from an add-on click. One of true or false
+let cd3; // did the user receive a theme as a query parameter. One of true or
+// false
+let cd4; // engaged with any theme-change event. One of true or false based on
+// whether user has fired any theme-change during their visit.
+let cd5; // hsla (csv) of the toolbar
+let cd6; // hsl (csv) of the toolbar_text
+let cd7; // hsl (csv) of the accentcolor
+let cd8; // hsl (csv) of the textcolor
+let cd9; // hsla (csv) of the toolbar_field
+let cd10; // hsl (csv) of the toolbar_field_text
+let cd11; // unique integer id of the background pattern selected
+
+const COLORS_TO_DIMENSIONS = {
+  toolbar: 'cd5',
+  toolbar_text: 'cd6',
+  accentcolor: 'cd7',
+  textcolor: 'cd8',
+  toolbar_field: 'cd9',
+  toolbar_field_text: 'cd10'
+};
+
+const hslaToCSV = (name, { h, s, l, a }) =>
+  `${h},${s},${l}${colorsWithAlpha.includes(name) ? `,${a}` : ''}`;
+
+const Metrics = {
+  init(appContext = 'web') {
+    /* eslint-disable prefer-destructuring */
+    analytics = new TestPilotGA({
+      aid: packageMeta.extensionManifest.applications.gecko.id,
+      an: packageMeta.extensionManifest.name,
+      av: packageMeta.version,
+      ds: appContext,
+      tid: packageMeta.config.GA_TRACKING_ID,
+      // TODO: add some env vars or use window.location to determine local / dev / stage / prod?
+      cd19: DEBUG ? 'dev' : 'production'
+    });
+    /* eslint-enable prefer-destructuring */
+
+    cm1 = 0;
+    cm2 = 0;
+    cm3 = 0;
+    cd1 = false;
+    cd2 = false;
+    cd3 = false;
+    cd4 = false;
+  },
+
+  sendEvent(...params) {
+    if (analytics) {
+      analytics.sendEvent(...params);
+    }
+  },
+
+  storeMiddleware() {
+    return ({ getState }) => next => action => {
+      const result = next(action);
+
+      if (action.type === 'SET_THEME') {
+        const theme = selectors.theme(getState());
+        this.setTheme(theme);
+        if (action.meta && action.meta.userEdit) {
+          this.setThemeChanged(true);
+        }
+      }
+
+      return result;
+    };
+  },
+
+  setHasAddon(value) {
+    cd1 = value;
+  },
+
+  setWasAddonClick(value) {
+    cd2 = value;
+  },
+
+  setReceivedTheme(value) {
+    cd3 = value;
+  },
+
+  setThemeChanged(value) {
+    cd4 = value;
+  },
+
+  themeToDimensions(theme) {
+    return Object.entries(theme.colors).reduce(
+      (acc, [name, hsla]) => ({
+        ...acc,
+        [COLORS_TO_DIMENSIONS[name]]: hslaToCSV(name, hsla)
+      }),
+      { cd11: theme.images.headerURL }
+    );
+  },
+
+  setTheme(theme) {
+    const themeDimensions = this.themeToDimensions(theme);
+    log('update theme', themeDimensions);
+    ({ cd5, cd6, cd7, cd8, cd9, cd10, cd11 } = themeDimensions);
+  },
+
+  installStart() {
+    if (installTimer) {
+      clearTimeout(installTimer);
+    }
+    installTimer = setTimeout(() => {
+      this.installFailure();
+    }, INSTALL_FAILURE_DELAY);
+
+    this.sendEvent('install-addon', 'button-click', {
+      el: 'install-trigger',
+      cm1,
+      cm2,
+      cm3,
+      cd3,
+      cd4,
+      cd5,
+      cd6,
+      cd7,
+      cd8,
+      cd9,
+      cd10,
+      cd11
+    });
+  },
+
+  installFailure() {
+    this.sendEvent('install-addon', 'poll-event', {
+      el: 'install-fail'
+    });
+  },
+
+  installSuccess() {
+    if (!installTimer) {
+      // Skip this event if there's no install timer in progress.
+      return;
+    }
+    clearTimeout(installTimer);
+    this.sendEvent('install-addon', 'poll-event', {
+      el: 'install-success'
+    });
+  },
+
+  themeChangeFull(themeId) {
+    cm1++;
+    this.setThemeChanged(true);
+    this.sendEvent('theme-change', 'select-full', {
+      el: themeId,
+      cm1,
+      cm2,
+      cm3,
+      cd1,
+      cd2
+    });
+  },
+
+  themeChangeBackground(backgroundId) {
+    cm2++;
+    this.setThemeChanged(true);
+    this.sendEvent('theme-change', 'select-background', {
+      el: backgroundId,
+      cm1,
+      cm2,
+      cm3,
+      cd1,
+      cd2,
+      cd3,
+      cd11
+    });
+  },
+
+  themeChangeColor(colorName) {
+    cm3++;
+    this.setThemeChanged(true);
+    this.sendEvent('theme-change', 'select-color', {
+      el: colorName,
+      cm1,
+      cm2,
+      cm3,
+      cd1,
+      cd2,
+      cd3
+    });
+  },
+
+  shareClick() {
+    this.sendEvent('share-engagement', 'button-click', {
+      cm1,
+      cm2,
+      cm3,
+      cd1,
+      cd2,
+      cd3,
+      cd4,
+      cd5,
+      cd6,
+      cd7,
+      cd8,
+      cd9,
+      cd10,
+      cd11
+    });
+  },
+
+  linkClick(el) {
+    // if el === download-firefox, add the following dimensions to this event
+    const downloadFirefoxDimensions =
+      el !== 'download-firefox' ? {} : { cd5, cd6, cd7, cd8, cd9, cd10, cd11 };
+    this.sendEvent('link-engagement', 'click', {
+      el,
+      cm1,
+      cm2,
+      cm3,
+      cd1,
+      cd2,
+      cd3,
+      cd4,
+      ...downloadFirefoxDimensions
+    });
+  },
+
+  receiveTheme(action, theme) {
+    this.sendEvent('receive-theme', 'button-click', {
+      el: action,
+      cd1,
+      ...this.themeToDimensions(theme)
+    });
+  },
+
+  finishVisit() {
+    this.sendEvent('finish-visit', 'leave', {
+      cm2,
+      cm3,
+      cd1,
+      cd2,
+      cd3,
+      cd4,
+      cd5,
+      cd6,
+      cd7,
+      cd8,
+      cd9,
+      cd10,
+      cd11
+    });
+  }
+};
+
+export default Metrics;

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -91,7 +91,7 @@ export const reducers = {
       userHasEdited: false,
       pendingTheme: null,
       savedThemes: {},
-      selectedColor: 'none',
+      selectedColor: null,
       hasExtension: false,
       loaderDelayExpired: false
     }

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -16,6 +16,8 @@ import {
   selectors,
   themeChangeActions
 } from '../lib/store';
+import Metrics from '../lib/metrics';
+
 import App from './lib/components/App';
 import storage from './lib/storage';
 
@@ -75,11 +77,16 @@ const composeEnhancers = composeWithDevTools({});
 const store = createAppStore(
   {},
   composeEnhancers(
-    applyMiddleware(updateExtensionThemeMiddleware, updateHistoryMiddleware)
+    applyMiddleware(
+      updateExtensionThemeMiddleware,
+      updateHistoryMiddleware,
+      Metrics.storeMiddleware()
+    )
   )
 );
 
 storage.init(store);
+Metrics.init();
 
 window.addEventListener('popstate', ({ state: { theme } }) =>
   store.dispatch({
@@ -99,6 +106,8 @@ window.addEventListener('message', ({ source, data: message }) => {
       const hasExtension = selectors.hasExtension(store.getState());
       if (!hasExtension) {
         store.dispatch(actions.ui.setHasExtension({ hasExtension: true }));
+        Metrics.installSuccess();
+        postMessage('setClientUUID', { clientUUID: Metrics.getClientUUID() });
         postMessage('setTheme', { theme: selectors.theme(store.getState()) });
       }
     }

--- a/src/web/lib/components/AppFooter/index.js
+++ b/src/web/lib/components/AppFooter/index.js
@@ -1,41 +1,77 @@
 import React from 'react';
 import ReactSVG from 'react-svg';
+
+import Metrics from '../../../../lib/metrics';
+
 import iconMoz from './moz-logo.svg';
 import iconGH from './github-logo.svg';
 import iconTwitter from './twitter-logo.svg';
 
 import './index.scss';
 
-export const AppFooter = () =>
+export const AppFooter = () => (
   <footer className="app-footer">
     <div className="app-footer__legal">
-      <a className="app-footer__legal-link" href="https://www.mozilla.org">
-        <ReactSVG path={ iconMoz } className="app-footer__legal-logo"/>
+      <a
+        className="app-footer__legal-link"
+        onClick={() => Metrics.linkClick('mozilla-logo')}
+        href="https://www.mozilla.org"
+      >
+        <ReactSVG path={iconMoz} className="app-footer__legal-logo" />
       </a>
-      <a className="app-footer__legal-link" href="https://www.mozilla.org/about/legal">
+      <a
+        className="app-footer__legal-link"
+        onClick={() => Metrics.linkClick('legal')}
+        href="https://www.mozilla.org/about/legal"
+      >
         Legal
       </a>
-      <a className="app-footer__legal-link" href="https://testpilot.firefox.com/about">
+      <a
+        className="app-footer__legal-link"
+        onClick={() => Metrics.linkClick('about')}
+        href="https://testpilot.firefox.com/about"
+      >
         About Test Pilot
       </a>
-      <a className="app-footer__legal-link" href="/legal">
+      <a
+        className="app-footer__legal-link"
+        onClick={() => Metrics.linkClick('privacy')}
+        href="/legal"
+      >
         Privacy
       </a>
-      <a className="app-footer__legal-link" href="/legal">
+      <a
+        className="app-footer__legal-link"
+        onClick={() => Metrics.linkClick('terms')}
+        href="/legal"
+      >
         Terms
       </a>
-      <a className="app-footer__legal-link" href="https://www.mozilla.org/privacy/websites/#cookies">
+      <a
+        className="app-footer__legal-link"
+        onClick={() => Metrics.linkClick('cookies')}
+        href="https://www.mozilla.org/privacy/websites/#cookies"
+      >
         Cookies
       </a>
     </div>
     <div className="app-footer__social">
-      <a className="app-footer__social-link" href="https://twitter.com/FxTestPilot">
-        <ReactSVG path={ iconTwitter } className="app-footer__social-logo"/>
+      <a
+        className="app-footer__social-link"
+        onClick={() => Metrics.linkClick('twitter')}
+        href="https://twitter.com/FxTestPilot"
+      >
+        <ReactSVG path={iconTwitter} className="app-footer__social-logo" />
       </a>
-      <a className="app-footer__social-link" href="https://github.com/mozilla/ThemesRFun/">
-        <ReactSVG path={ iconGH } className="app-footer__social-logo"/>
+      <a
+        className="app-footer__social-link"
+        onClick={() => Metrics.linkClick('github')}
+        href="https://github.com/mozilla/ThemesRFun/"
+      >
+        <ReactSVG path={iconGH} className="app-footer__social-logo" />
       </a>
     </div>
-  </footer>;
+  </footer>
+);
 
 export default AppFooter;

--- a/src/web/lib/components/AppHeader/index.js
+++ b/src/web/lib/components/AppHeader/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import ReactSVG from 'react-svg';
 
 import { surveyUrl } from '../../../../lib/constants';
+import Metrics from '../../../../lib/metrics';
+
 import iconFeedback from './feedback.svg';
 import './index.scss';
 
@@ -16,23 +18,32 @@ export const AppHeader = ({ hasExtension, appVersion = null }) => {
         <div className="app-header__icon" />
         <header>
           <h1>Themer</h1>
-          <h3>A <a href="https://testpilot.firefox.com" target="_blank"
-           rel="noopener noreferrer">Firefox Test Pilot</a> Experiment</h3>
+          <h3>
+            <a
+              href="https://testpilot.firefox.com"
+              onClick={() => Metrics.linkClick('test-pilot')}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Firefox Test Pilot
+            </a>{' '}
+            Experiment
+          </h3>
         </header>
       </div>
-      {hasExtension &&
-        <a href={ survey }
-           title="survey link"
-           className="app-header__survey"
-           target="_blank"
-           rel="noopener noreferrer">
-            <span>Feedback</span>
-            <ReactSVG
-                    style={{ fill: '#fff' }}
-                    path={iconFeedback}
-                  />
-           </a>
-      }
+      {hasExtension && (
+        <a
+          href={survey}
+          onClick={() => Metrics.linkClick('survey')}
+          title="survey link"
+          className="app-header__survey"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <span>Feedback</span>
+          <ReactSVG style={{ fill: '#fff' }} path={iconFeedback} />
+        </a>
+      )}
     </div>
   );
 };

--- a/src/web/lib/components/Banner/index.js
+++ b/src/web/lib/components/Banner/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { DOWNLOAD_FIREFOX_URL } from '../../../../lib/constants';
+import Metrics from '../../../../lib/metrics';
 
 import './index.scss';
 
@@ -10,7 +11,11 @@ export const Banner = ({ isFirefox, addonUrl, bottom = false }) => (
     {isFirefox ? (
       <div className="banner__content">
         <span>Put the 🔥 in Firefox</span>
-        <a href={addonUrl} className="banner__button">
+        <a
+          href={addonUrl}
+          onClick={() => Metrics.installStart()}
+          className="banner__button"
+        >
           Install Themer
         </a>
       </div>

--- a/src/web/lib/components/BrowserPreview/index.js
+++ b/src/web/lib/components/BrowserPreview/index.js
@@ -15,7 +15,7 @@ export const BrowserPreview = ({
   setSelectedColor,
   selectedTab = 0,
   children = null,
-  setTheme = null
+  onClick: onClickDoll = null
 }) => {
   const clickSelectColor = name => e => {
     if (setSelectedColor) {
@@ -26,8 +26,8 @@ export const BrowserPreview = ({
   };
 
   const clickDoll = e => {
-    if (setTheme) {
-      setTheme({ theme });
+    if (onClickDoll) {
+      onClickDoll(e);
       e.stopPropagation();
     }
     return false;

--- a/src/web/lib/components/PresetThemeSelector/index.js
+++ b/src/web/lib/components/PresetThemeSelector/index.js
@@ -3,23 +3,34 @@ import React from 'react';
 import BrowserPreview from '../BrowserPreview';
 
 import { presetColors } from '../../../../lib/constants';
+import Metrics from '../../../../lib/metrics';
 
 import './index.scss';
 
-export const PresetThemeSelector = ({ setTheme }) =>
+export const PresetThemeSelector = ({ setTheme }) => (
   <div className="preset-theme-selector">
     <h2>Choose a preset theme</h2>
-    { presetColors.map((colors, key) => {
+    {presetColors.map((colors, themeId) => {
       const theme = {
         images: '',
         colors
       };
       return (
-        <div key={key} className="preset-theme-preview">
-          <BrowserPreview {...{ size: 'small', theme, setTheme }} />
+        <div key={themeId} className="preset-theme-preview">
+          <BrowserPreview
+            {...{
+              size: 'small',
+              theme,
+              onClick: () => {
+                setTheme({ theme });
+                Metrics.themeChangeFull(themeId);
+              }
+            }}
+          />
         </div>
       );
     })}
-  </div>;
+  </div>
+);
 
 export default PresetThemeSelector;

--- a/src/web/lib/components/SavedThemeSelector/index.js
+++ b/src/web/lib/components/SavedThemeSelector/index.js
@@ -16,10 +16,20 @@ export const SavedThemeSelector = ({ setTheme, savedThemes, deleteTheme }) => {
       <h2>Saved themes</h2>
       {sortedSavedThemes.map(([key, { theme }]) => (
         <div key={key} className="saved-theme-preview">
-          <button className="delete-theme" onClick={() => deleteTheme(key)} title="delete">
+          <button
+            className="delete-theme"
+            onClick={() => deleteTheme(key)}
+            title="delete"
+          >
             <img src={iconClose} />
           </button>
-          <BrowserPreview {...{ size: 'small', theme, setTheme }} />
+          <BrowserPreview
+            {...{
+              size: 'small',
+              theme,
+              onClick: () => setTheme({ theme })
+            }}
+          />
         </div>
       ))}
     </div>

--- a/src/web/lib/components/SharedThemeDialog/index.js
+++ b/src/web/lib/components/SharedThemeDialog/index.js
@@ -1,13 +1,16 @@
 import React from 'react';
+import Metrics from '../../../../lib/metrics';
 import BrowserPreview from '../BrowserPreview';
 import './index.scss';
 
 export const SharedThemeDialog = ({ pendingTheme, setTheme, clearPendingTheme }) => {
   const onApply = () => {
+    Metrics.receiveTheme('apply', pendingTheme);
     setTheme({ theme: pendingTheme });
     clearPendingTheme();
   };
   const onSkip = () => {
+    Metrics.receiveTheme('reject', pendingTheme);
     clearPendingTheme();
   };
   const onClickBackdrop = ev => {

--- a/src/web/lib/components/ThemeBackgroundPicker/index.js
+++ b/src/web/lib/components/ThemeBackgroundPicker/index.js
@@ -3,15 +3,25 @@ import classnames from 'classnames';
 import onClickOutside from 'react-onclickoutside';
 
 import { colorToCSS } from '../../../../lib/utils';
+import Metrics from '../../../../lib/metrics';
 
 import './index.scss';
 
 const bgImages = require.context('../../../../images/', false, /bg-.*\.png/);
 
-const Background = ({ src, active, setBackground, accentcolor }) =>
+const Background = ({
+  src,
+  backgroundId,
+  active,
+  setBackground,
+  accentcolor
+}) => (
   <div
     className={classnames('bg', { active })}
-    onClick={() => setBackground({ url: src })}
+    onClick={() => {
+      setBackground({ url: src });
+      Metrics.themeChangeBackground(backgroundId);
+    }}
   >
     <div
       className="bg__inner"
@@ -20,7 +30,8 @@ const Background = ({ src, active, setBackground, accentcolor }) =>
         backgroundImage: `url(${bgImages(src)})`
       }}
     />
-  </div>;
+  </div>
+);
 
 class ThemeBackgroundPicker extends React.Component {
   constructor(props) {
@@ -43,23 +54,38 @@ class ThemeBackgroundPicker extends React.Component {
     const { selected } = this.state;
     const accentcolor = colorToCSS(theme.colors.accentcolor);
     // Note: default theme initializes with no bg so we have to check before adding bg to CSS
-    const backgroundSwatch = theme.images.headerURL ? `url(${bgImages(theme.images.headerURL)})` : '';
+    const backgroundSwatch = theme.images.headerURL
+      ? `url(${bgImages(theme.images.headerURL)})`
+      : '';
     return (
-      <div className={classnames('theme-background-picker', { selected })} onClick={ this.handleClick.bind(this) }>
-        <span className="theme-background-picker__swatch"
-          style={{ backgroundColor: accentcolor, backgroundImage: backgroundSwatch }}
+      <div
+        className={classnames('theme-background-picker', { selected })}
+        onClick={this.handleClick.bind(this)}
+      >
+        <span
+          className="theme-background-picker__swatch"
+          style={{
+            backgroundColor: accentcolor,
+            backgroundImage: backgroundSwatch
+          }}
         />
         <span className="theme-background-picker__text">Theme Texture</span>
         <div className="theme-background-picker__backgrounds">
           <div className="theme-background-picker__backgrounds-inner">
             {bgImages
               .keys()
-              .map((src, key) =>
+              .map((src, backgroundId) => (
                 <Background
-                  key={key}
-                  {...{ src, accentcolor, setBackground, active: theme.images.headerURL === src }}
+                  key={backgroundId}
+                  {...{
+                    src,
+                    backgroundId,
+                    accentcolor,
+                    setBackground,
+                    active: theme.images.headerURL === src
+                  }}
                 />
-              )}
+              ))}
           </div>
         </div>
       </div>

--- a/src/web/lib/components/ThemeColorsEditor/index.js
+++ b/src/web/lib/components/ThemeColorsEditor/index.js
@@ -4,12 +4,16 @@ import { SketchPicker } from 'react-color';
 import onClickOutside from 'react-onclickoutside';
 import { colorLabels, colorsWithAlpha } from '../../../../lib/constants';
 import { colorToCSS } from '../../../../lib/utils';
+import Metrics from '../../../../lib/metrics';
 
 import './index.scss';
 
 class ThemeColorsEditor extends React.Component {
   handleClickOutside() {
-    this.props.setSelectedColor({ name: null });
+    const { selectedColor, setSelectedColor } = this.props;
+    if (selectedColor !== null) {
+      setSelectedColor({ name: null });
+    }
   }
 
   render() {
@@ -37,8 +41,10 @@ class ThemeColorsEditor extends React.Component {
                   <SketchPicker
                     color={{ h: color.h, s: color.s, l: color.l, a: color.a * 0.01 }}
                     disableAlpha={!colorsWithAlpha.includes(name)}
-                    onChangeComplete={({ hsl: { h, s, l, a } }) =>
-                      setColor({ name, h, s: s * 100, l: l * 100, a: a * 100 })}
+                    onChangeComplete={({ hsl: { h, s, l, a } }) => {
+                      setColor({ name, h, s: s * 100, l: l * 100, a: a * 100 });
+                      Metrics.themeChangeColor(name);
+                    }}
                   />
                 </span>
               </li>

--- a/src/web/lib/components/ThemeUrl/index.js
+++ b/src/web/lib/components/ThemeUrl/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Metrics from '../../../../lib/metrics';
 
 import './index.scss';
 
@@ -9,7 +10,10 @@ export default class ThemeUrl extends React.Component {
       themeUrl: '',
       copied: false
     };
-    this.handleCopied = () => this.setState({ copied: true });
+    this.handleCopied = () => {
+      this.setState({ copied: true });
+      Metrics.shareClick();
+    };
   }
 
   componentDidMount() {


### PR DESCRIPTION
- New Metrics module with methods to send various pings

- Add a random per-client UUID to localStorage, generating as necessary

- Wire up metrics pings to links and major app interactions

- Implement timer-based add-on install success/fail event

- Simplify BrowserPreview to only handle onClick rather than setting the
  theme directly, so that presets and saved themes can handle metric
  pings differently

- Only deselect current color if there's one selected

Fixes #46