### PR TITLE
Include Fira fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "clipboard": "^1.7.1",
+    "fira": "github:mozilla/fira#4.202",
     "json-url": "^2.3.1",
     "query-string": "^5.0.1",
     "react": "^16.1.0",

--- a/src/web/index.scss
+++ b/src/web/index.scss
@@ -1,3 +1,4 @@
+@import '~fira/fira.css';
 @import './lib/colors.scss';
 
 :root {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -62,6 +62,19 @@ module.exports = {
         })
       },
       {
+        test: /\.(ttf|woff|eot)$/i,
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              hash: 'sha512',
+              digest: 'hex',
+              name: 'fonts/[name]-[hash].[ext]'
+            }
+          }
+        ]
+      },
+      {
         test: /\.(jpe?g|gif|png|svg)$/i,
         use: [
           {


### PR DESCRIPTION
- Add last release from mozilla/fira as a dependency

- Webpack loader rules for fonts

- Import Fira into project CSS

Fixes #95