### PR TITLE
Remove unused alpha property from presetColors themes

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -96,20 +96,17 @@ export const presetColors = [
     toolbar_text: {
       h: 213,
       s: 43,
-      l: 89,
-      a: 100
+      l: 89
     },
     accentcolor: {
       h: 187,
       s: 77,
-      l: 53,
-      a: 100
+      l: 53
     },
     textcolor: {
       h: 187,
       s: 0,
-      l: 33,
-      a: 100
+      l: 33
     },
     toolbar_field: {
       h: 211,
@@ -120,8 +117,7 @@ export const presetColors = [
     toolbar_field_text: {
       h: 317,
       s: 100,
-      l: 64,
-      a: 100
+      l: 64
     }
   },
   {
@@ -134,20 +130,17 @@ export const presetColors = [
     toolbar_text: {
       h: 172,
       s: 0,
-      l: 8,
-      a: 100
+      l: 8
     },
     accentcolor: {
       h: 266,
       s: 35,
-      l: 26,
-      a: 100
+      l: 26
     },
     textcolor: {
       h: 174,
       s: 86,
-      l: 50,
-      a: 100
+      l: 50
     },
     toolbar_field: {
       h: 260,
@@ -158,8 +151,7 @@ export const presetColors = [
     toolbar_field_text: {
       h: 172,
       s: 0,
-      l: 3,
-      a: 100
+      l: 3
     }
   },
   {
@@ -172,20 +164,17 @@ export const presetColors = [
     toolbar_text: {
       h: 65,
       s: 0,
-      l: 100,
-      a: 100
+      l: 100
     },
     accentcolor: {
       h: 231,
       s: 63,
-      l: 8,
-      a: 100
+      l: 8
     },
     textcolor: {
       h: 213,
       s: 43,
-      l: 89,
-      a: 100
+      l: 89
     },
     toolbar_field: {
       h: 233,
@@ -196,8 +185,7 @@ export const presetColors = [
     toolbar_field_text: {
       h: 0,
       s: 0,
-      l: 100,
-      a: 100
+      l: 100
     }
   }, {
     toolbar: {
@@ -209,20 +197,17 @@ export const presetColors = [
     toolbar_text: {
       h: 65,
       s: 0,
-      l: 100,
-      a: 100
+      l: 100
     },
     accentcolor: {
       h: 228,
       s: 10,
-      l: 92,
-      a: 100
+      l: 92
     },
     textcolor: {
       h: 213,
       s: 54,
-      l: 49,
-      a: 100
+      l: 49
     },
     toolbar_field: {
       h: 233,
@@ -233,8 +218,7 @@ export const presetColors = [
     toolbar_field_text: {
       h: 212,
       s: 54,
-      l: 48,
-      a: 100
+      l: 48
     }
   }, {
     // Hotdog Stand 🌭
@@ -247,20 +231,17 @@ export const presetColors = [
     toolbar_text: {
       h: 0,
       s: 0,
-      l: 0,
-      a: 100
+      l: 0
     },
     accentcolor: {
       h: 0,
       s: 100,
-      l: 50,
-      a: 100
+      l: 50
     },
     textcolor: {
       h: 0,
       s: 0,
-      l: 0,
-      a: 100
+      l: 0
     },
     toolbar_field: {
       h: 0,
@@ -271,8 +252,7 @@ export const presetColors = [
     toolbar_field_text: {
       h: 0,
       s: 0,
-      l: 100,
-      a: 100
+      l: 100
     }
   }
 ];


### PR DESCRIPTION
I built a really crappy color schema linter using [**ajv**](http://npm.im/ajv) and this seems to all pass locally. 🤷‍♀️ 