### PR TITLE
Bug fix for title in preset themes appearing as a color choice in editor

### DIFF
--- a/src/web/lib/components/ThemeColorsEditor/index.js
+++ b/src/web/lib/components/ThemeColorsEditor/index.js
@@ -24,10 +24,14 @@ class ThemeColorsEditor extends React.Component {
       setSelectedColor
     } = this.props;
 
+    // Select only the color properties from the theme.
+    const colorKeys = Object.keys(colors)
+      .filter(name => name in colorLabels);
+
     return (
       <div className="theme-colors-editor">
         <ul className="colors">
-          {Object.keys(colors).map((name, idx) => {
+          {colorKeys.map((name, idx) => {
             const color = colors[name];
             return [
               <li


### PR DESCRIPTION
Just noticed that "title" was appearing as a clickable color choice in the editor. This should fix.